### PR TITLE
Updating instructions for firmware location

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ The latest stable version can be downloaded from the ardupilot [website][Firmwar
 
 ## How to push an updated version of ArduPlane on a Disco
 
-### Old Disco firmware ###
+### Old Disco firmwares ###
 
-These instructions are for old version of Disco firmware.
+These instructions are for old versions of Disco firmware.
 
 First connect to the drone's wifi network, it's name as the form DISCO-XXXXXX.
 It will give you an address on the 192.168.42.0/24 network, the address of the
@@ -90,7 +90,7 @@ send apm-plane-disco in the right place by executing:
 An error regarding the APM directory creation is normal and can be safely
 ignored.
 
-### Recent firmware ###
+### Recent firmwares ###
 
 First connect to the drone's wifi network, named DISCO-XXXXXX. It will give you an address on the 192.168.42.0/24 network, the address of the drone is 192.168.42.1. Then connect to the drone's ftp server and upload the file arduplane into the folder internal\_000/ardupilot/.
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ these instructions can lead to.
 This document is in markdown format and is best read with a markdown viewer. In
 command line, one can use `pandoc README.md | lynx -stdin`.
 
-## How to start / restart ArduPlane for Parrot Disco
-
-Just press three times on the on/off button, the original autopilot will be
-killed and ArduPlane will be launched instead.
-If ArduPlane was already running, it will be restarted.
-Now you can interact with ArduPlane the way you want, please refer to the
-[ArduPlane documentation][ArduPlane] for more information.
-
 ## How to build ArduPlane for Parrot Disco (optional)
 
 ### Needed packages
@@ -94,6 +86,19 @@ ignored.
 
 First connect to the drone's wifi network, named DISCO-XXXXXX. It will give you an address on the 192.168.42.0/24 network, the address of the drone is 192.168.42.1. Then connect to the drone's ftp server and upload the file arduplane into the folder internal\_000/ardupilot/.
 
+## How to start / restart ArduPlane for Parrot Disco
+
+After loading arduplane file, with the Disco powered on, just press three times on the on/off button, you will hear some [beeps][Beep]. The original autopilot will be
+killed and ArduPlane will be launched instead. If ArduPlane was already running, it will be restarted.
+Now you can interact with ArduPlane the way you want, please refer to the [ArduPlane documentation][ArduPlane] for more information.
+
+Note that the original Disco firmware will be loaded at next startup. 
+
+## Configuration ##
+
+A sample configuration file can be downloaded from [ArduPilot GitHub][Parameters]. This file can be loaded with any GCS.
+Main configuration steps are described on [ardupilot wiki][Configuration].
+
 ## Troubleshooting
 
 ### wget-ing the toolchains fails with a security warning
@@ -104,3 +109,6 @@ First connect to the drone's wifi network, named DISCO-XXXXXX. It will give you 
 [ADB]:https://developer.android.com/studio/command-line/adb.html
 [ArduPlane]:http://ardupilot.org/plane/
 [Firmware]:http://firmware.ardupilot.org/Plane/stable/disco/
+[Beep]:http://ardupilot.org/plane/docs/common-sounds-pixhawkpx4.html#common-sounds-pixhawkpx4
+[Parameters]:https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/Frame_params/Parrot_Disco/Parrot_Disco.param
+[Configuration]:http://ardupilot.org/plane/docs/airframe-disco.html#loading-parameters

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If ArduPlane was already running, it will be restarted.
 Now you can interact with ArduPlane the way you want, please refer to the
 [ArduPlane documentation][ArduPlane] for more information.
 
-## How to build ArduPlane for Parrot Disco
+## How to build ArduPlane for Parrot Disco (optional)
 
 ### Needed packages
 
@@ -64,7 +64,15 @@ For debian-based distributions (tested on debian 8):
         $ repo sync
         $ ./build.sh all final -j5
 
+## How to download the latest version of ArduPlane
+
+The latest stable version can be downloaded from the ardupilot [website][Firmware]. Just download the file named *arduplane*.
+
 ## How to push an updated version of ArduPlane on a Disco
+
+### Old Disco firmware ###
+
+These instructions are for old version of Disco firmware.
 
 First connect to the drone's wifi network, it's name as the form DISCO-XXXXXX.
 It will give you an address on the 192.168.42.0/24 network, the address of the
@@ -82,7 +90,11 @@ send apm-plane-disco in the right place by executing:
 An error regarding the APM directory creation is normal and can be safely
 ignored.
 
-## Troobleshooting
+### Recent firmware ###
+
+First connect to the drone's wifi network, named DISCO-XXXXXX. It will give you an address on the 192.168.42.0/24 network, the address of the drone is 192.168.42.1. Then connect to the drone's ftp server and upload the file arduplane into the folder internal\_000/ardupilot/.
+
+## Troubleshooting
 
 ### wget-ing the toolchains fails with a security warning
 
@@ -91,3 +103,4 @@ ignored.
 [Disco]:https://www.parrot.com/fr/drones/parrot-disco-fpv#-parrot-disco-fpv
 [ADB]:https://developer.android.com/studio/command-line/adb.html
 [ArduPlane]:http://ardupilot.org/plane/
+[Firmware]:http://firmware.ardupilot.org/Plane/stable/disco/


### PR DESCRIPTION
Arduplane firmware location is different for new Disco firmware. A link to download the already compiled arduplane firmware would be useful. Here is a small update for these suggestions.